### PR TITLE
Revise browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,10 +42,9 @@
   },
   "browserslist": [
     "last 4 Chrome versions",
-    "Edge >= 12",
+    "last 4 Edge versions",
+    "last 4 Firefox versions",
     "Firefox ESR",
-    "last 4 Safari versions",
-    "last 4 Opera versions",
-    "Explorer >= 10"
+    "last 4 Safari versions"
   ]
 }


### PR DESCRIPTION
To reflect the change in https://github.com/spectre-org/spectre-docs/pull/15

This instantly results in a big file size reduction, because old `-ms-` prefixes no longer need to be included. Very nice :)