### PR TITLE
Add CSS variables for color

### DIFF
--- a/src/_autocomplete.scss
+++ b/src/_autocomplete.scss
@@ -12,7 +12,7 @@
 
     &.is-focused {
       @include control-shadow();
-      border-color: $primary-color;
+      border-color: var(--spectre-primary-color);
     }
 
     .form-input {

--- a/src/_avatars.scss
+++ b/src/_avatars.scss
@@ -1,9 +1,11 @@
+@use "functions/color" as *;
+
 // Avatars
 .avatar {
   @include avatar-base();
-  background: $primary-color;
+  background: var(--spectre-primary-color);
   border-radius: 50%;
-  color: rgba($light-color, .85);
+  color: opacity-css(var(--spectre-light-color), .85);
   display: inline-block;
   font-weight: 300;
   line-height: 1.25;
@@ -34,7 +36,7 @@
 
   .avatar-icon,
   .avatar-presence {
-    background: $bg-color-light;
+    background: var(--spectre-bg-color-light);
     bottom: 14.64%;
     height: 50%;
     padding: $border-width-lg;
@@ -46,22 +48,22 @@
   }
 
   .avatar-presence {
-    background: $gray-color;
-    box-shadow: 0 0 0 $border-width-lg $light-color;
+    background: var(--spectre-gray-color);
+    box-shadow: 0 0 0 $border-width-lg var(--spectre-light-color);
     border-radius: 50%;
     height: .5em;
     width: .5em;
 
     &.online {
-      background: $success-color;
+      background: var(--spectre-success-color);
     }
 
     &.busy {
-      background: $error-color;
+      background: var(--spectre-error-color);
     }
 
     &.away {
-      background: $warning-color;
+      background: var(--spectre-warning-color);
     }
   }
 

--- a/src/_badges.scss
+++ b/src/_badges.scss
@@ -6,11 +6,11 @@
   &[data-badge],
   &:not([data-badge]) {
     &::after {
-      background: $primary-color;
+      background: var(--spectre-primary-color);
       background-clip: padding-box;
       border-radius: .5rem;
-      box-shadow: 0 0 0 .1rem $bg-color-light;
-      color: $light-color;
+      box-shadow: 0 0 0 .1rem var(--spectre-bg-color-light);
+      color: var(--spectre-light-color);
       content: attr(data-badge);
       display: inline-block;
       transform: translate(-.05rem, -.5rem);

--- a/src/_bars.scss
+++ b/src/_bars.scss
@@ -1,6 +1,6 @@
 // Bars
 .bar {
-  background: $bg-color-dark;
+  background: var(--spectre-bg-color-dark);
   border-radius: $border-radius;
   display: flex;
   flex-wrap: nowrap;
@@ -13,8 +13,8 @@
 
   // TODO: attr() support
   .bar-item {
-    background: $primary-color;
-    color: $light-color;
+    background: var(--spectre-primary-color);
+    color: var(--spectre-light-color);
     display: block;
     font-size: $font-size-sm;
     flex-shrink: 0;
@@ -47,13 +47,13 @@
     padding: 0;
     position: absolute;
     &:not(:last-child):first-child {
-      background: $bg-color-dark;
+      background: var(--spectre-bg-color-dark);
       z-index: $zindex-0;
     }
   }
 
   .bar-slider-btn {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border: 0;
     border-radius: 50%;
     height: $unit-3;
@@ -65,7 +65,7 @@
     width: $unit-3;
 
     &:active {
-      box-shadow: 0 0 0 .1rem $primary-color;
+      box-shadow: 0 0 0 .1rem var(--spectre-primary-color);
     }
   }
 }

--- a/src/_base.scss
+++ b/src/_base.scss
@@ -13,8 +13,8 @@ html {
 }
 
 body {
-  background: $body-bg;
-  color: $body-font-color;
+  background: var(--spectre-body-bg);
+  color: var(--spectre-body-font-color);
   font-family: $body-font-family;
   font-size: $font-size;
   overflow-x: hidden;
@@ -22,7 +22,7 @@ body {
 }
 
 a {
-  color: $link-color;
+  color: var(--spectre-link-color);
   outline: none;
   text-decoration: none;
 
@@ -34,11 +34,11 @@ a {
   &:hover,
   &:active,
   &.active {
-    color: $link-color-dark;
+    color: var(--spectre-link-color-dark);
     text-decoration: underline;
   }
 
   &:visited {
-    color: $link-color-light;
+    color: var(--spectre-link-color-light);
   }
 }

--- a/src/_breadcrumbs.scss
+++ b/src/_breadcrumbs.scss
@@ -5,7 +5,7 @@
   padding: $unit-1 0;
 
   .breadcrumb-item {
-    color: $gray-color-dark;
+    color: var(--spectre-gray-color-dark);
     display: inline-block;
     margin: 0;
     padding: $unit-1 0;
@@ -14,13 +14,13 @@
       margin-right: $unit-1;
 
       a {
-        color: $gray-color-dark;
+        color: var(--spectre-gray-color-dark);
       }
     }
 
     &:not(:first-child) {
       &::before {
-        color: $gray-color-dark;
+        color: var(--spectre-gray-color-dark);
         content: "/";
         padding-right: $unit-2;
       }

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -1,10 +1,12 @@
+@use "functions/color" as *;
+
 // Buttons
 .btn {
   appearance: none;
-  background: $bg-color-light;
-  border: $border-width solid $primary-color;
+  background: var(--spectre-bg-color-light);
+  border: $border-width solid var(--spectre-primary-color);
   border-radius: $border-radius;
-  color: $primary-color;
+  color: var(--spectre-primary-color);
   cursor: pointer;
   display: inline-block;
   font-size: $font-size;
@@ -23,20 +25,20 @@
   }
   &:focus,
   &:hover {
-    background: $secondary-color;
-    border-color: $primary-color-dark;
+    background: var(--spectre-secondary-color);
+    border-color: var(--spectre-primary-color-dark);
     text-decoration: none;
   }
   &:active,
   &.active {
-    background: $primary-color-dark;
-    border-color: darken($primary-color-dark, 5%);
-    color: $light-color;
+    background: var(--spectre-primary-color-dark);
+    border-color: darken-css(var(--spectre-primary-color-dark), 5%);
+    color: var(--spectre-light-color);
     text-decoration: none;
     &.loading {
       &::after {
-        border-bottom-color: $light-color;
-        border-left-color: $light-color;
+        border-bottom-color: var(--spectre-light-color);
+        border-left-color: var(--spectre-light-color);
       }
     }
   }
@@ -50,48 +52,48 @@
 
   // Button Primary
   &.btn-primary {
-    background: $primary-color;
-    border-color: $primary-color-dark;
-    color: $light-color;
+    background: var(--spectre-primary-color);
+    border-color: var(--spectre-primary-color-dark);
+    color: var(--spectre-light-color);
     &:focus,
     &:hover {
-      background: darken($primary-color-dark, 2%);
-      border-color: darken($primary-color-dark, 5%);
-      color: $light-color;
+      background: darken-css(var(--spectre-primary-color-dark), 2%);
+      border-color: darken-css(var(--spectre-primary-color-dark), 5%);
+      color: var(--spectre-light-color);
     }
     &:active,
     &.active {
-      background: darken($primary-color-dark, 4%);
-      border-color: darken($primary-color-dark, 7%);
-      color: $light-color;
+      background: darken-css(var(--spectre-primary-color-dark), 4%);
+      border-color: darken-css(var(--spectre-primary-color-dark), 7%);
+      color: var(--spectre-light-color);
     }
     &.loading {
       &::after {
-        border-bottom-color: $light-color;
-        border-left-color: $light-color;
+        border-bottom-color: var(--spectre-light-color);
+        border-left-color: var(--spectre-light-color);
       }
     }
   }
 
   // Button Colors
   &.btn-success {
-    @include button-variant($success-color);
+    @include button-variant(var(--spectre-success-color));
   }
 
   &.btn-error {
-    @include button-variant($error-color);
+    @include button-variant(var(--spectre-error-color));
   }
 
   // Button Link
   &.btn-link {
     background: transparent;
     border-color: transparent;
-    color: $link-color;
+    color: var(--spectre-link-color);
     &:focus,
     &:hover,
     &:active,
     &.active {
-      color: $link-color-dark;
+      color: var(--spectre-link-color-dark);
     }
   }
 
@@ -145,7 +147,7 @@
 
     &:focus,
     &:hover {
-      background: rgba($bg-color, .5);
+      background: opacity-css(var(--spectre-bg-color), .5);
       opacity: .95;
     }
 

--- a/src/_calendars.scss
+++ b/src/_calendars.scss
@@ -1,13 +1,15 @@
+@use "functions/color" as *;
+
 // Calendars
 .calendar {
-  border: $border-width solid $border-color;
+  border: $border-width solid var(--spectre-border-color);
   border-radius: $border-radius;
   display: block;
   min-width: 280px;
 
   .calendar-nav {
     align-items: center;
-    background: $bg-color;
+    background: var(--spectre-bg-color);
     border-top-left-radius: $border-radius;
     border-top-right-radius: $border-radius;
     display: flex;
@@ -29,15 +31,15 @@
   }
 
   .calendar-header {
-    background: $bg-color;
-    border-bottom: $border-width solid $border-color;
-    color: $gray-color;
+    background: var(--spectre-bg-color);
+    border-bottom: $border-width solid var(--spectre-border-color);
+    color: var(--spectre-gray-color);
     font-size: $font-size-sm;
     text-align: center;
   }
 
   .calendar-body {
-    color: $gray-color-dark;
+    color: var(--spectre-gray-color-dark);
   }
 
   .calendar-date {
@@ -49,7 +51,7 @@
       background: transparent;
       border: $border-width solid transparent;
       border-radius: 50%;
-      color: $gray-color-dark;
+      color: var(--spectre-gray-color-dark);
       cursor: pointer;
       font-size: $font-size-sm;
       height: $unit-7;
@@ -65,8 +67,8 @@
       width: $unit-7;
 
       &.date-today {
-        border-color: $secondary-color-dark;
-        color: $primary-color;
+        border-color: var(--spectre-secondary-color-dark);
+        color: var(--spectre-primary-color);
       }
 
       &:focus {
@@ -75,16 +77,16 @@
 
       &:focus,
       &:hover {
-        background: $secondary-color-light;
-        border-color: $secondary-color-dark;
-        color: $primary-color;
+        background: var(--spectre-secondary-color-light);
+        border-color: var(--spectre-secondary-color-dark);
+        color: var(--spectre-primary-color);
         text-decoration: none;
       }
       &:active,
       &.active {
-        background: $primary-color-dark;
-        border-color: darken($primary-color-dark, 5%);
-        color: $light-color;
+        background: var(--spectre-primary-color-dark);
+        border-color: darken-css(var(--spectre-primary-color-dark), 5%);
+        color: var(--spectre-light-color);
       }
 
       // Calendar badge support
@@ -121,7 +123,7 @@
     position: relative;
 
     &::before {
-      background: $secondary-color;
+      background: var(--spectre-secondary-color);
       content: "";
       height: $unit-7;
       left: 0;
@@ -144,14 +146,14 @@
     &.range-start,
     &.range-end {
       .date-item {
-        background: $primary-color-dark;
-        border-color: darken($primary-color-dark, 5%);
-        color: $light-color;
+        background: var(--spectre-primary-color-dark);
+        border-color: darken-css(var(--spectre-primary-color-dark), 5%);
+        color: var(--spectre-light-color);
       }
     }
 
     .date-item {
-      color: $primary-color;
+      color: var(--spectre-primary-color);
     }
   }
 
@@ -161,8 +163,8 @@
       padding: 0;
 
       .calendar-date {
-        border-bottom: $border-width solid $border-color;
-        border-right: $border-width solid $border-color;
+        border-bottom: $border-width solid var(--spectre-border-color);
+        border-right: $border-width solid var(--spectre-border-color);
         display: flex;
         flex-direction: column;
         height: 5.5rem;

--- a/src/_cards.scss
+++ b/src/_cards.scss
@@ -1,7 +1,7 @@
 // Cards
 .card {
-  background: $bg-color-light;
-  border: $border-width solid $border-color;
+  background: var(--spectre-bg-color-light);
+  border: $border-width solid var(--spectre-border-color);
   border-radius: $border-radius;
   display: flex;
   flex-direction: column;

--- a/src/_carousels.scss
+++ b/src/_carousels.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Carousels
 // The number of carousel images
 $carousel-number: 8;
@@ -9,11 +11,11 @@ $carousel-number: 8;
 }
 
 %carousel-nav-checked { 
-  color: $gray-color-light;
+  color: var(--spectre-gray-color-light);
 }
 
 .carousel {
-  background: $bg-color;
+  background: var(--spectre-bg-color);
   display: block;
   overflow: hidden;
   position: relative;
@@ -51,9 +53,9 @@ $carousel-number: 8;
 
     .item-prev,
     .item-next {
-      background: rgba($gray-color-light, .25);
-      border-color: rgba($gray-color-light, .5);
-      color: $gray-color-light;
+      background: opacity-css(var(--spectre-gray-color-light), .25);
+      border-color: opacity-css(var(--spectre-gray-color-light), .5);
+      color: var(--spectre-gray-color-light);
       opacity: 0;
       position: absolute;
       top: 50%;
@@ -94,7 +96,7 @@ $carousel-number: 8;
     z-index: $zindex-1;
 
     .nav-item {
-      color: rgba($gray-color-light, .5);
+      color: opacity-css(var(--spectre-gray-color-light), .5);
       display: block;
       flex: 1 0 auto;
       height: $unit-8;

--- a/src/_chips.scss
+++ b/src/_chips.scss
@@ -1,7 +1,7 @@
 // Chips
 .chip {
   align-items: center;
-  background: $bg-color-dark;
+  background: var(--spectre-bg-color-dark);
   border-radius: 5rem;
   display: inline-flex;
   font-size: 90%;
@@ -17,8 +17,8 @@
   white-space: nowrap;
 
   &.active {
-    background: $primary-color;
-    color: $light-color;
+    background: var(--spectre-primary-color);
+    color: var(--spectre-light-color);
   }
 
   .avatar {

--- a/src/_codes.scss
+++ b/src/_codes.scss
@@ -1,17 +1,19 @@
+@use "functions/color" as *;
+
 // Codes
 code {
   @include label-base();
-  @include label-variant($code-color, lighten($code-color, 42.5%));
+  @include label-variant(var(--spectre-code-color), lighten-css(var(--spectre-code-color), 42.5%));
   font-size: 85%;
 }
 
 .code {
   border-radius: $border-radius;
-  color: $body-font-color;
+  color: var(--spectre-body-font-color);
   position: relative;
 
   &::before {
-    color: $gray-color;
+    color: var(--spectre-gray-color);
     content: attr(data-lang);
     font-size: $font-size-sm;
     position: absolute;
@@ -20,7 +22,7 @@ code {
   }
 
   code {
-    background: $bg-color;
+    background: var(--spectre-bg-color);
     color: inherit;
     display: block;
     line-height: 1.5;

--- a/src/_comparison-sliders.scss
+++ b/src/_comparison-sliders.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Image comparison slider
 // Credit: http://codepen.io/solipsistacp/pen/Gpmaq
 .comparison-slider {
@@ -55,7 +57,7 @@
       background: currentColor;
       border-radius: 50%;
       box-shadow: 0 -5px, 0 5px;
-      color: $light-color;
+      color: var(--spectre-light-color);
       content: "";
       height: 3px;
       pointer-events: none;
@@ -88,9 +90,9 @@
   }
 
   .comparison-label {
-    background: rgba($dark-color, .5);
+    background: opacity-css(var(--spectre-dark-color), .5);
     bottom: $unit-4;
-    color: $light-color;
+    color: var(--spectre-light-color);
     padding: $unit-1 $unit-2;
     position: absolute;
     user-select: none;

--- a/src/_empty.scss
+++ b/src/_empty.scss
@@ -1,8 +1,8 @@
 // Empty states (or Blank slates)
 .empty {
-  background: $bg-color;
+  background: var(--spectre-bg-color);
   border-radius: $border-radius;
-  color: $gray-color-dark;
+  color: var(--spectre-gray-color-dark);
   text-align: center;
   padding: $unit-16 $unit-8;
 

--- a/src/_filters.scss
+++ b/src/_filters.scss
@@ -3,8 +3,8 @@
 $filter-number: 8 !default;
 
 %filter-checked-nav { 
-  background: $primary-color;
-  color: $light-color;
+  background: var(--spectre-primary-color);
+  color: var(--spectre-light-color);
 }
 
 %filter-checked-body { 

--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Forms
 .form-group {
   &:not(:last-child) {
@@ -35,11 +37,11 @@ legend {
 // Form element: Input
 .form-input {
   appearance: none;
-  background: $bg-color-light;
+  background: var(--spectre-bg-color-light);
   background-image: none;
-  border: $border-width solid $border-color-dark;
+  border: $border-width solid var(--spectre-border-color-dark);
   border-radius: $border-radius;
-  color: $body-font-color;
+  color: var(--spectre-body-font-color);
   display: block;
   font-size: $font-size;
   height: $control-size;
@@ -52,10 +54,10 @@ legend {
   width: 100%;
   &:focus {
     @include control-shadow();
-    border-color: $primary-color;
+    border-color: var(--spectre-primary-color);
   }
   &::placeholder {
-    color: $gray-color;
+    color: var(--spectre-gray-color);
   }
 
   // Input sizes
@@ -94,25 +96,25 @@ textarea.form-input {
 
 // Form element: Input hint
 .form-input-hint {
-  color: $gray-color;
+  color: var(--spectre-gray-color);
   font-size: $font-size-sm;
   margin-top: $unit-1;
 
   .has-success &,
   .is-success + & {
-    color: $success-color;
+    color: var(--spectre-success-color);
   }
 
   .has-error &,
   .is-error + & {
-    color: $error-color;
+    color: var(--spectre-error-color);
   }
 }
 
 // Form element: Select
 .form-select {
   appearance: none;
-  border: $border-width solid $border-color-dark;
+  border: $border-width solid var(--spectre-border-color-dark);
   border-radius: $border-radius;
   color: inherit;
   font-size: $font-size;
@@ -122,10 +124,10 @@ textarea.form-input {
   padding: $control-padding-y $control-padding-x;
   vertical-align: middle;
   width: 100%;
-  background: $bg-color-light; 
+  background: var(--spectre-bg-color-light); 
   &:focus {
     @include control-shadow();
-    border-color: $primary-color;
+    border-color: var(--spectre-primary-color);
   }
   &::-ms-expand {
     display: none;
@@ -155,7 +157,7 @@ textarea.form-input {
     }
   }
   &:not([multiple]):not([size]) {
-    background: $bg-color-light url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem;
+    background: var(--spectre-bg-color-light) url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%204%205'%3E%3Cpath%20fill='%23667189'%20d='M2%200L0%202h4zm0%205L0%203h4z'/%3E%3C/svg%3E") no-repeat right .35rem center / .4rem .5rem;
     padding-right: $control-icon-size + $control-padding-x;
   }
 }
@@ -216,16 +218,16 @@ textarea.form-input {
     width: 1px;
     &:focus + .form-icon {
       @include control-shadow();
-      border-color: $primary-color;
+      border-color: var(--spectre-primary-color);
     }
     &:checked + .form-icon {
-      background: $primary-color;
-      border-color: $primary-color;
+      background: var(--spectre-primary-color);
+      border-color: var(--spectre-primary-color);
     }
   }
 
   .form-icon {
-    border: $border-width solid $border-color-dark;
+    border: $border-width solid var(--spectre-border-color-dark);
     cursor: pointer;
     display: inline-block;
     position: absolute;
@@ -247,7 +249,7 @@ textarea.form-input {
 .form-checkbox,
 .form-radio {
   .form-icon {
-    background: $bg-color-light;
+    background: var(--spectre-bg-color-light);
     height: $control-icon-size;
     left: 0;
     top: ($control-size-sm - $control-icon-size) * .5;
@@ -256,7 +258,7 @@ textarea.form-input {
 
   input {
     &:active + .form-icon {
-      background: $bg-color-dark;
+      background: var(--spectre-bg-color-dark);
     }
   }
 }
@@ -269,7 +271,7 @@ textarea.form-input {
     &:checked + .form-icon {
       &::before {
         background-clip: padding-box;
-        border: $border-width-lg solid $light-color;
+        border: $border-width-lg solid var(--spectre-light-color);
         border-left-width: 0;
         border-top-width: 0;
         content: "";
@@ -284,10 +286,10 @@ textarea.form-input {
       }
     }
     &:indeterminate + .form-icon {
-      background: $primary-color;
-      border-color: $primary-color;
+      background: var(--spectre-primary-color);
+      border-color: var(--spectre-primary-color);
       &::before {
-        background: $bg-color-light;
+        background: var(--spectre-bg-color-light);
         content: "";
         height: 2px;
         left: 50%;
@@ -308,7 +310,7 @@ textarea.form-input {
   input {
     &:checked + .form-icon {
       &::before {
-        background: $bg-color-light;
+        background: var(--spectre-bg-color-light);
         border-radius: 50%;
         content: "";
         height: 6px;
@@ -327,7 +329,7 @@ textarea.form-input {
   padding-left: ($unit-8 + $control-padding-x);
 
   .form-icon {
-    background: $gray-color;
+    background: var(--spectre-gray-color);
     background-clip: padding-box;
     border-radius: $unit-2 + $border-width;
     height: $unit-4 + $border-width * 2;
@@ -335,7 +337,7 @@ textarea.form-input {
     top: ($control-size-sm - $unit-4) * .5 - $border-width;
     width: $unit-8;
     &::before {
-      background: $bg-color-light;
+      background: var(--spectre-bg-color-light);
       border-radius: 50%;
       content: "";
       display: block;
@@ -356,7 +358,7 @@ textarea.form-input {
     }
     &:active + .form-icon {
       &::before {
-        background: $bg-color;
+        background: var(--spectre-bg-color);
       }
     }
   }
@@ -367,8 +369,8 @@ textarea.form-input {
   display: flex;
 
   .input-group-addon {
-    background: $bg-color;
-    border: $border-width solid $border-color-dark;
+    background: var(--spectre-bg-color);
+    border: $border-width solid var(--spectre-border-color-dark);
     border-radius: $border-radius;
     line-height: $line-height;
     padding: $control-padding-y $control-padding-x;
@@ -431,19 +433,19 @@ textarea.form-input {
 .form-select {
   .has-success &,
   &.is-success {
-    background: lighten($success-color, 53%);
-    border-color: $success-color;
+    background: lighten-css(var(--spectre-success-color), 53%);
+    border-color: var(--spectre-success-color);
     &:focus {
-      @include control-shadow($success-color);
+      @include control-shadow(var(--spectre-success-color));
     }
   }
 
   .has-error &,
   &.is-error {
-    background: lighten($error-color, 53%);
-    border-color: $error-color;
+    background: lighten-css(var(--spectre-error-color), 53%);
+    border-color: var(--spectre-error-color);
     &:focus {
-      @include control-shadow($error-color);
+      @include control-shadow(var(--spectre-error-color));
     }
   }
 }
@@ -454,18 +456,18 @@ textarea.form-input {
   .has-error &,
   &.is-error {
     .form-icon {
-      border-color: $error-color;
+      border-color: var(--spectre-error-color);
     }
 
     input {
       &:checked + .form-icon {
-        background: $error-color;
-        border-color: $error-color;
+        background: var(--spectre-error-color);
+        border-color: var(--spectre-error-color);
       }
 
       &:focus + .form-icon {
-        @include control-shadow($error-color);
-        border-color: $error-color;
+        @include control-shadow(var(--spectre-error-color));
+        border-color: var(--spectre-error-color);
       }
     }
   }
@@ -476,8 +478,8 @@ textarea.form-input {
   &.is-error {
     input {
       &:indeterminate + .form-icon {
-        background: $error-color;
-        border-color: $error-color;
+        background: var(--spectre-error-color);
+        border-color: var(--spectre-error-color);
       }
     }
   }
@@ -487,14 +489,14 @@ textarea.form-input {
 .form-input {
   &:not(:placeholder-shown) {
     &:invalid {
-      border-color: $error-color;
+      border-color: var(--spectre-error-color);
       &:focus {
-        @include control-shadow($error-color);
-        background: lighten($error-color, 53%);
+        @include control-shadow(var(--spectre-error-color));
+        background: lighten-css(var(--spectre-error-color), 53%);
       }
 
       & + .form-input-hint {
-        color: $error-color;
+        color: var(--spectre-error-color);
       }
     }
   }
@@ -505,7 +507,7 @@ textarea.form-input {
 .form-select {
   &:disabled,
   &.disabled {
-    background-color: $bg-color-dark;
+    background-color: var(--spectre-bg-color-dark);
     cursor: not-allowed;
     opacity: .5;
   }
@@ -513,7 +515,7 @@ textarea.form-input {
 
 .form-input {
   &[readonly] {
-    background-color: $bg-color;
+    background-color: var(--spectre-bg-color);
   }
 }
 
@@ -521,7 +523,7 @@ input {
   &:disabled,
   &.disabled {
     & + .form-icon {
-      background: $bg-color-dark;
+      background: var(--spectre-bg-color-dark);
       cursor: not-allowed;
       opacity: .5;
     }
@@ -533,7 +535,7 @@ input {
     &:disabled,
     &.disabled {
       & + .form-icon::before {
-        background: $bg-color-light;
+        background: var(--spectre-bg-color-light);
       }
     }
   }

--- a/src/_labels.scss
+++ b/src/_labels.scss
@@ -1,7 +1,9 @@
+@use "functions/color" as *;
+
 // Labels
 .label {
   @include label-base();
-  @include label-variant(lighten($body-font-color, 5%), $bg-color-dark);
+  @include label-variant(lighten-css(var(--spectre-body-font-color), 5%), var(--spectre-bg-color-dark));
   display: inline-block;
 
   // Label rounded
@@ -13,22 +15,22 @@
 
   // Label colors
   &.label-primary {
-    @include label-variant($light-color, $primary-color);
+    @include label-variant(var(--spectre-light-color), var(--spectre-primary-color));
   }
 
   &.label-secondary {
-    @include label-variant($primary-color, $secondary-color);
+    @include label-variant(var(--spectre-primary-color), var(--spectre-secondary-color));
   }
 
   &.label-success {
-    @include label-variant($light-color, $success-color);
+    @include label-variant(var(--spectre-light-color), var(--spectre-success-color));
   }
 
   &.label-warning {
-    @include label-variant($light-color, $warning-color);
+    @include label-variant(var(--spectre-light-color), var(--spectre-warning-color));
   }
 
   &.label-error {
-    @include label-variant($light-color, $error-color);
+    @include label-variant(var(--spectre-light-color), var(--spectre-error-color));
   }
 }

--- a/src/_media.scss
+++ b/src/_media.scss
@@ -69,7 +69,7 @@ video.video-responsive {
   margin: 0 0 $layout-spacing 0;
 
   .figure-caption {
-    color: $gray-color-dark;
+    color: var(--spectre-gray-color-dark);
     margin-top: $layout-spacing;
   }
 }

--- a/src/_menus.scss
+++ b/src/_menus.scss
@@ -1,7 +1,7 @@
 // Menus
 .menu {
   @include shadow-variant(.05rem);
-  background: $bg-color-light;
+  background: var(--spectre-bg-color-light);
   border-radius: $border-radius;
   list-style: none;
   margin: 0;
@@ -30,13 +30,13 @@
       text-decoration: none;
       &:focus,
       &:hover {
-        background: $secondary-color;
-        color: $primary-color;
+        background: var(--spectre-secondary-color);
+        color: var(--spectre-primary-color);
       }
       &:active,
       &.active {
-        background: $secondary-color;
-        color: $primary-color;
+        background: var(--spectre-secondary-color);
+        color: var(--spectre-primary-color);
       }
     }
 

--- a/src/_meters.scss
+++ b/src/_meters.scss
@@ -2,7 +2,7 @@
 // Credit: https://css-tricks.com/html5-meter-element/
 .meter {
   appearance: none;
-  background: $bg-color;
+  background: var(--spectre-bg-color);
   border: 0;
   border-radius: $border-radius;
   display: block;
@@ -21,19 +21,19 @@
   }
 
   &::-webkit-meter-bar {
-    background: $bg-color;
+    background: var(--spectre-bg-color);
   }
 
   &::-webkit-meter-optimum-value {
-    background: $success-color;
+    background: var(--spectre-success-color);
   }
 
   &::-webkit-meter-suboptimum-value {
-    background: $warning-color;
+    background: var(--spectre-warning-color);
   }
 
   &::-webkit-meter-even-less-good-value {
-    background: $error-color;
+    background: var(--spectre-error-color);
   }
 
   &::-moz-meter-bar,
@@ -44,14 +44,14 @@
   }
 
   &:-moz-meter-optimum::-moz-meter-bar {
-    background: $success-color;
+    background: var(--spectre-success-color);
   }
 
   &:-moz-meter-sub-optimum::-moz-meter-bar {
-    background: $warning-color;
+    background: var(--spectre-warning-color);
   }
 
   &:-moz-meter-sub-sub-optimum::-moz-meter-bar {
-    background: $error-color;
+    background: var(--spectre-error-color);
   }
 }

--- a/src/_modals.scss
+++ b/src/_modals.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Modals
 .modal {
   align-items: center;
@@ -19,7 +21,7 @@
     z-index: $zindex-4;
 
     .modal-overlay {
-      background: rgba($bg-color, .75);
+      background: opacity-css(var(--spectre-bg-color), .75);
       bottom: 0;
       cursor: default;
       display: block;
@@ -44,7 +46,7 @@
 
   &.modal-lg {
     .modal-overlay {
-      background: $bg-color-light;
+      background: var(--spectre-bg-color-light);
     }
 
     .modal-container {
@@ -56,7 +58,7 @@
 
 .modal-container {
   @include shadow-variant(.2rem);
-  background: $bg-color-light;
+  background: var(--spectre-bg-color-light);
   border-radius: $border-radius;
   display: flex;
   flex-direction: column;
@@ -70,7 +72,7 @@
   }
 
   .modal-header {
-    color: $dark-color;
+    color: var(--spectre-dark-color);
     padding: $unit-4;
   }
 

--- a/src/_navs.scss
+++ b/src/_navs.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Navs
 .nav {
   display: flex;
@@ -7,21 +9,21 @@
 
   .nav-item {
     a {
-      color: $gray-color-dark;
+      color: var(--spectre-gray-color-dark);
       padding: $unit-1 $unit-2;
       text-decoration: none;
       &:focus,
       &:hover {
-        color: $primary-color;
+        color: var(--spectre-primary-color);
       }
     }
     &.active {
       & > a {
-        color: darken($gray-color-dark, 10%);
+        color: darken-css(var(--spectre-gray-color-dark), 10%);
         font-weight: bold;
         &:focus,
         &:hover {
-          color: $primary-color;
+          color: var(--spectre-primary-color);
         }
       }
     }

--- a/src/_off-canvas.scss
+++ b/src/_off-canvas.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Off canvas menus
 $off-canvas-breakpoint: $size-lg !default;
 
@@ -22,7 +24,7 @@ $off-canvas-breakpoint: $size-lg !default;
   }
 
   .off-canvas-sidebar {
-    background: $bg-color;
+    background: var(--spectre-bg-color);
     bottom: 0;
     min-width: 10rem;
     overflow-y: auto;
@@ -46,7 +48,7 @@ $off-canvas-breakpoint: $size-lg !default;
   }
 
   .off-canvas-overlay {
-    background: rgba($dark-color, .1);
+    background: opacity-css(var(--spectre-dark-color), .1);
     border-color: transparent;
     border-radius: 0;
     bottom: 0;

--- a/src/_pagination.scss
+++ b/src/_pagination.scss
@@ -20,7 +20,7 @@
       text-decoration: none;
       &:focus,
       &:hover {
-        color: $primary-color;
+        color: var(--spectre-primary-color);
       }
     }
 
@@ -34,8 +34,8 @@
 
     &.active {
       a {
-        background: $primary-color;
-        color: $light-color;
+        background: var(--spectre-primary-color);
+        color: var(--spectre-light-color);
       }
     }
 

--- a/src/_panels.scss
+++ b/src/_panels.scss
@@ -1,6 +1,6 @@
 // Panels
 .panel {
-  border: $border-width solid $border-color;
+  border: $border-width solid var(--spectre-border-color);
   border-radius: $border-radius;
   display: flex;
   flex-direction: column;

--- a/src/_parallax.scss
+++ b/src/_parallax.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Parallax
 $parallax-deg: 3deg !default;
 $parallax-offset: 4.5px !default;
@@ -5,6 +7,10 @@ $parallax-offset-z: 50px !default;
 $parallax-perspective: 1000px !default;
 $parallax-scale: .95 !default;
 $parallax-fade-color: rgba(255, 255, 255, .35) !default;
+
+:root {
+  --spectre-parallax-fade-color: #{$parallax-fade-color};
+}
 
 // Mixin: Parallax direction
 @mixin parallax-dir() {
@@ -42,14 +48,14 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
 
   .parallax-front {
     align-items: center;
-    color: $light-color;
+    color: var(--spectre-light-color);
     display: flex;
     height: 100%;
     justify-content: center;
     left: 0;
     position: absolute;
     text-align: center;
-    text-shadow: 0 0 20px rgba($dark-color, .75);
+    text-shadow: 0 0 20px opacity-css(var(--spectre-dark-color), .75);
     top: 0;
     transform: translateZ($parallax-offset-z) scale($parallax-scale);
     transition: transform .4s;
@@ -67,7 +73,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
       transform: perspective($parallax-perspective) rotateX($parallax-deg) rotateY(-$parallax-deg);
 
       &::before {
-        background: linear-gradient(135deg, $parallax-fade-color 0%, transparent 50%);
+        background: linear-gradient(135deg, var(--spectre-parallax-fade-color) 0%, transparent 50%);
       }
 
       .parallax-front {
@@ -86,7 +92,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
       transform: perspective($parallax-perspective) rotateX($parallax-deg) rotateY($parallax-deg);
 
       &::before {
-        background: linear-gradient(-135deg, $parallax-fade-color 0%, transparent 50%);
+        background: linear-gradient(-135deg, var(--spectre-parallax-fade-color) 0%, transparent 50%);
       }
 
       .parallax-front {
@@ -105,7 +111,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
       transform: perspective($parallax-perspective) rotateX(-$parallax-deg) rotateY(-$parallax-deg);
 
       &::before {
-        background: linear-gradient(45deg, $parallax-fade-color 0%, transparent 50%);
+        background: linear-gradient(45deg, var(--spectre-parallax-fade-color) 0%, transparent 50%);
       }
 
       .parallax-front {
@@ -124,7 +130,7 @@ $parallax-fade-color: rgba(255, 255, 255, .35) !default;
       transform: perspective($parallax-perspective) rotateX(-$parallax-deg) rotateY($parallax-deg);
 
       &::before {
-        background: linear-gradient(-45deg, $parallax-fade-color 0%, transparent 50%);
+        background: linear-gradient(-45deg, var(--spectre-parallax-fade-color) 0%, transparent 50%);
       }
 
       .parallax-front {

--- a/src/_progress.scss
+++ b/src/_progress.scss
@@ -2,10 +2,10 @@
 // Credit: https://css-tricks.com/html5-progress-element/
 .progress {
   appearance: none;
-  background: $bg-color-dark;
+  background: var(--spectre-bg-color-dark);
   border: 0;
   border-radius: $border-radius;
-  color: $primary-color;
+  color: var(--spectre-primary-color);
   height: $unit-1;
   position: relative;
   width: 100%;
@@ -16,18 +16,18 @@
   }
 
   &::-webkit-progress-value {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border-radius: $border-radius;
   }
 
   &::-moz-progress-bar {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border-radius: $border-radius;
   }
 
   &:indeterminate {
     animation: progress-indeterminate 1.5s linear infinite;
-    background: $bg-color-dark linear-gradient(to right, $primary-color 30%, $bg-color-dark 30%) top left / 150% 150% no-repeat;
+    background: var(--spectre-bg-color-dark) linear-gradient(to right, var(--spectre-primary-color) 30%, var(--spectre-bg-color-dark) 30%) top left / 150% 150% no-repeat;
 
     &::-moz-progress-bar {
       background: transparent;

--- a/src/_sliders.scss
+++ b/src/_sliders.scss
@@ -21,7 +21,7 @@
   // Slider Thumb
   &::-webkit-slider-thumb {
     -webkit-appearance: none;
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border: 0;
     border-radius: 50%;
     height: $unit-3;
@@ -30,7 +30,7 @@
     width: $unit-3;
   }
   &::-moz-range-thumb {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border: 0;
     border-radius: 50%;
     height: $unit-3;
@@ -38,7 +38,7 @@
     width: $unit-3;
   }
   &::-ms-thumb {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
     border: 0;
     border-radius: 50%;
     height: $unit-3;
@@ -61,39 +61,39 @@
   &:disabled,
   &.disabled {
     &::-webkit-slider-thumb {
-      background: $gray-color-light;
+      background: var(--spectre-gray-color-light);
       transform: scale(1);
     }
     &::-moz-range-thumb {
-      background: $gray-color-light;
+      background: var(--spectre-gray-color-light);
       transform: scale(1);
     }
     &::-ms-thumb {
-      background: $gray-color-light;
+      background: var(--spectre-gray-color-light);
       transform: scale(1);
     }
   }
 
   // Slider Track
   &::-webkit-slider-runnable-track {
-    background: $bg-color-dark;
+    background: var(--spectre-bg-color-dark);
     border-radius: $border-radius;
     height: $unit-h;
     width: 100%;
   }
   &::-moz-range-track {
-    background: $bg-color-dark;
+    background: var(--spectre-bg-color-dark);
     border-radius: $border-radius;
     height: $unit-h;
     width: 100%;
   }
   &::-ms-track {
-    background: $bg-color-dark;
+    background: var(--spectre-bg-color-dark);
     border-radius: $border-radius;
     height: $unit-h;
     width: 100%;
   }
   &::-ms-fill-lower {
-    background: $primary-color;
+    background: var(--spectre-primary-color);
   }
 }

--- a/src/_steps.scss
+++ b/src/_steps.scss
@@ -14,7 +14,7 @@
     position: relative;
 
     &:not(:first-child)::before {
-      background: $primary-color;
+      background: var(--spectre-primary-color);
       content: "";
       height: 2px;
       left: -50%;
@@ -24,14 +24,14 @@
     }
 
     a {
-      color: $primary-color;
+      color: var(--spectre-primary-color);
       display: inline-block;
       padding: 20px 10px 0;
       text-decoration: none;
 
       &::before {
-        background: $primary-color;
-        border: $border-width-lg solid $light-color;
+        background: var(--spectre-primary-color);
+        border: $border-width-lg solid var(--spectre-light-color);
         border-radius: 50%;
         content: "";
         display: block;
@@ -48,21 +48,21 @@
     &.active {
       a {
         &::before {
-          background: $light-color;
-          border: $border-width-lg solid $primary-color;
+          background: var(--spectre-light-color);
+          border: $border-width-lg solid var(--spectre-primary-color);
         }
       }
 
       & ~ .step-item {
         &::before {
-          background: $border-color;
+          background: var(--spectre-border-color);
         }
 
         a {
-          color: $gray-color;
+          color: var(--spectre-gray-color);
 
           &::before {
-            background: $border-color;
+            background: var(--spectre-border-color);
           }
         }
       }

--- a/src/_tables.scss
+++ b/src/_tables.scss
@@ -12,7 +12,7 @@
   &.table-striped {
     tbody {
       tr:nth-of-type(odd) {
-        background: $bg-color;
+        background: var(--spectre-bg-color);
       }
     }
   }
@@ -22,7 +22,7 @@
     tbody {
       tr {
         &.active {
-          background: $bg-color-dark;
+          background: var(--spectre-bg-color-dark);
         }
       }
     }
@@ -32,7 +32,7 @@
     tbody {
       tr {
         &:hover {
-          background: $bg-color-dark;
+          background: var(--spectre-bg-color-dark);
         }
       }
     }
@@ -48,7 +48,7 @@
 
   td,
   th {
-    border-bottom: $border-width solid $border-color;
+    border-bottom: $border-width solid var(--spectre-border-color);
     padding: $unit-3 $unit-2;
   }
   th {

--- a/src/_tabs.scss
+++ b/src/_tabs.scss
@@ -1,7 +1,7 @@
 // Tabs
 .tab {
   align-items: center;
-  border-bottom: $border-width solid $border-color;
+  border-bottom: $border-width solid var(--spectre-border-color);
   display: flex;
   flex-wrap: wrap;
   list-style: none;
@@ -19,13 +19,13 @@
       text-decoration: none;
       &:focus,
       &:hover {
-        color: $link-color;
+        color: var(--spectre-link-color);
       }
     }
     &.active a,
     a.active {
-      border-bottom-color: $primary-color;
-      color: $link-color;
+      border-bottom-color: var(--spectre-primary-color);
+      color: var(--spectre-link-color);
     }
 
     &.tab-action {

--- a/src/_timelines.scss
+++ b/src/_timelines.scss
@@ -5,7 +5,7 @@
     margin-bottom: $unit-6;
     position: relative;
     &::before {
-      background: $border-color;
+      background: var(--spectre-border-color);
       content: "";
       height: 100%;
       left: 11px;
@@ -26,14 +26,14 @@
     .timeline-icon {
       align-items: center;
       border-radius: 50%;
-      color: $light-color;
+      color: var(--spectre-light-color);
       display: flex;
       height: $unit-6;
       justify-content: center;
       text-align: center;
       width: $unit-6;
       &::before {
-        border: $border-width-lg solid $primary-color;
+        border: $border-width-lg solid var(--spectre-primary-color);
         border-radius: 50%;
         content: "";
         display: block;
@@ -45,7 +45,7 @@
       }
 
       &.icon-lg {
-        background: $primary-color;
+        background: var(--spectre-primary-color);
         line-height: $line-height;
         &::before {
           content: none;

--- a/src/_toasts.scss
+++ b/src/_toasts.scss
@@ -1,31 +1,31 @@
 // Toasts
 .toast {
-  @include toast-variant($dark-color);
-  border: $border-width solid $dark-color;
+  @include toast-variant(var(--spectre-dark-color));
+  border: $border-width solid var(--spectre-dark-color);
   border-radius: $border-radius;
-  color: $light-color;
+  color: var(--spectre-light-color);
   display: block;
   padding: $layout-spacing;
   width: 100%;
 
   &.toast-primary {
-    @include toast-variant($primary-color);
+    @include toast-variant(var(--spectre-primary-color));
   }
 
   &.toast-success {
-    @include toast-variant($success-color);
+    @include toast-variant(var(--spectre-success-color));
   }
 
   &.toast-warning {
-    @include toast-variant($warning-color);
+    @include toast-variant(var(--spectre-warning-color));
   }
 
   &.toast-error {
-    @include toast-variant($error-color);
+    @include toast-variant(var(--spectre-error-color));
   }
 
   a {
-    color: $light-color;
+    color: var(--spectre-light-color);
     text-decoration: underline;
     
     &:focus,

--- a/src/_tooltips.scss
+++ b/src/_tooltips.scss
@@ -1,11 +1,13 @@
+@use "functions/color" as *;
+
 // Tooltips
 .tooltip {
   position: relative;
   &::after {
-    background: rgba($dark-color, .95);
+    background: opacity-css(var(--spectre-dark-color), .95);
     border-radius: $border-radius;
     bottom: 100%;
-    color: $light-color;
+    color: var(--spectre-light-color);
     content: attr(data-tooltip);
     display: block;
     font-size: $font-size-sm;

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Typography
 // Headings
 h1,
@@ -65,20 +67,20 @@ abbr[title] {
 
 kbd {
   @include label-base();
-  @include label-variant($light-color, $dark-color);
+  @include label-variant(var(--spectre-light-color), var(--spectre-dark-color));
   font-size: $font-size-sm;
 }
 
 mark {
-  @include label-variant($body-font-color, $highlight-color);
-  border-bottom: $unit-o solid darken($highlight-color, 15%);
+  @include label-variant(var(--spectre-body-font-color), var(--spectre-highlight-color));
+  border-bottom: $unit-o solid darken-css(var(--spectre-highlight-color), 15%);
   border-radius: $border-radius;
   padding: $unit-o $unit-h 0;
 }
 
 // Blockquote
 blockquote {
-  border-left: $border-width-lg solid $border-color;
+  border-left: $border-width-lg solid var(--spectre-border-color);
   margin-left: 0;
   padding: $unit-2 $unit-4;
 

--- a/src/_variables-css.scss
+++ b/src/_variables-css.scss
@@ -1,0 +1,43 @@
+// Core colors
+:root{
+  --spectre-primary-color: #{$primary-color};
+  --spectre-primary-color-dark: #{$primary-color-dark};
+  --spectre-primary-color-light: #{$primary-color-light};
+  --spectre-secondary-color: #{$secondary-color};
+  --spectre-secondary-color-dark: #{$secondary-color-dark};
+  --spectre-secondary-color-light: #{$secondary-color-light};
+}
+
+// Gray colors
+:root {
+  --spectre-dark-color: #{$dark-color};
+  --spectre-light-color: #{$light-color};
+  --spectre-gray-color: #{$gray-color};
+  --spectre-gray-color-dark: #{$gray-color-dark};
+  --spectre-gray-color-light: #{$gray-color-light};
+
+  --spectre-border-color: #{$border-color};
+  --spectre-border-color-dark: #{$border-color-dark};
+  --spectre-border-color-light: #{$border-color-light};
+  --spectre-bg-color: #{$bg-color};
+  --spectre-bg-color-dark: #{$bg-color-dark};
+  --spectre-bg-color-light: #{$bg-color-light};
+}
+
+// Control colors
+:root {
+  --spectre-success-color: #{$success-color};
+  --spectre-warning-color: #{$warning-color};
+  --spectre-error-color: #{$error-color};
+}
+
+// Other colors
+:root {
+  --spectre-code-color: #{$code-color};
+  --spectre-highlight-color: #{$highlight-color};
+  --spectre-body-bg: #{$body-bg};
+  --spectre-body-font-color: #{$body-font-color};
+  --spectre-link-color: #{$link-color};
+  --spectre-link-color-dark: #{$link-color-dark};
+  --spectre-link-color-light: #{$link-color-light};
+}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,3 +1,5 @@
+@use "functions/color" as *;
+
 // Core variables
 $version: "0.5.10";
 
@@ -6,25 +8,25 @@ $rtl: false !default;
 
 // Core colors
 $primary-color: #5755d9 !default;
-$primary-color-dark: darken($primary-color, 3%) !default;
-$primary-color-light: lighten($primary-color, 3%) !default;
-$secondary-color: lighten($primary-color, 37.5%) !default;
-$secondary-color-dark: darken($secondary-color, 3%) !default;
-$secondary-color-light: lighten($secondary-color, 3%) !default;
+$primary-color-dark: darken-css(var(--spectre-primary-color), 3%) !default;
+$primary-color-light: lighten-css(var(--spectre-primary-color), 3%) !default;
+$secondary-color: lighten-css(var(--spectre-primary-color), 37.5%) !default;
+$secondary-color-dark: darken-css(var(--spectre-secondary-color), 3%) !default;
+$secondary-color-light: lighten-css(var(--spectre-secondary-color), 3%) !default;
 
 // Gray colors
 $dark-color: #303742 !default;
 $light-color: #fff !default;
-$gray-color: lighten($dark-color, 55%) !default;
-$gray-color-dark: darken($gray-color, 30%) !default;
-$gray-color-light: lighten($gray-color, 20%) !default;
+$gray-color: lighten-css(var(--spectre-dark-color), 55%) !default;
+$gray-color-dark: darken-css(var(--spectre-gray-color), 30%) !default;
+$gray-color-light: lighten-css(var(--spectre-gray-color), 20%) !default;
 
-$border-color: lighten($dark-color, 65%) !default;
-$border-color-dark: darken($border-color, 10%) !default;
-$border-color-light: lighten($border-color, 8%) !default;
-$bg-color: lighten($dark-color, 75%) !default;
-$bg-color-dark: darken($bg-color, 3%) !default;
-$bg-color-light: $light-color !default;
+$border-color: lighten-css(var(--spectre-dark-color), 65%) !default;
+$border-color-dark: darken-css(var(--spectre-border-color), 10%) !default;
+$border-color-light: lighten-css(var(--spectre-border-color), 8%) !default;
+$bg-color: lighten-css(var(--spectre-dark-color), 75%) !default;
+$bg-color-dark: darken-css(var(--spectre-bg-color), 3%) !default;
+$bg-color-light: var(--spectre-light-color) !default;
 
 // Control colors
 $success-color: #32b643 !default;
@@ -34,11 +36,11 @@ $error-color: #e85600 !default;
 // Other colors
 $code-color: #d73e48 !default;
 $highlight-color: #ffe9b3 !default;
-$body-bg: $bg-color-light !default;
-$body-font-color: lighten($dark-color, 5%) !default;
-$link-color: $primary-color !default;
-$link-color-dark: darken($link-color, 10%) !default;
-$link-color-light: lighten($link-color, 10%) !default;
+$body-bg: var(--spectre-bg-color-light) !default;
+$body-font-color: lighten-css(var(--spectre-dark-color), 5%) !default;
+$link-color: var(--spectre-primary-color) !default;
+$link-color-dark: darken-css(var(--spectre-link-color), 10%) !default;
+$link-color-light: lighten-css(var(--spectre-link-color), 10%) !default;
 
 // Fonts
 // Credit: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/

--- a/src/functions/_color.scss
+++ b/src/functions/_color.scss
@@ -1,0 +1,18 @@
+@use 'sass:math';
+
+// TODO: Colors should be scaled in oklch rather than hsl, as it 
+// provides more accurate colors and supports a wider color space.
+// Unfortunately, changing to oklch requires reevalutaion of each
+// color, so it needs a lot of work.
+@function lighten-css($color, $percentage) {
+  $delta: math.div($percentage, 1%);
+  @return hsl(from $color h s calc(l + $delta) / alpha);
+}
+
+@function darken-css($color, $percentage) {
+  @return lighten-css($color, $percentage * -1);
+}
+
+@function opacity-css($color, $opacity){
+  @return hsl(from $color h s l / $opacity);
+}

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -1,33 +1,35 @@
+@use "functions/color" as *;
+
 // Button variant mixin
-@mixin button-variant($color: $primary-color) {
+@mixin button-variant($color: var(--spectre-primary-color)) {
   background: $color;
-  border-color: darken($color, 3%);
-  color: $light-color;
+  border-color: darken-css($color, 3%);
+  color: var(--spectre-light-color);
   &:focus {
     @include control-shadow($color);
   }
   &:focus,
   &:hover {
-    background: darken($color, 2%);
-    border-color: darken($color, 5%);
-    color: $light-color;
+    background: darken-css($color, 2%);
+    border-color: darken-css($color, 5%);
+    color: var(--spectre-light-color);
   }
   &:active,
   &.active {
-    background: darken($color, 7%);
-    border-color: darken($color, 10%);
-    color: $light-color;
+    background: darken-css($color, 7%);
+    border-color: darken-css($color, 10%);
+    color: var(--spectre-light-color);
   }
   &.loading {
     &::after {
-      border-bottom-color: $light-color;
-      border-left-color: $light-color;
+      border-bottom-color: var(--spectre-light-color);
+      border-left-color: var(--spectre-light-color);
     }
   }
 }
 
-@mixin button-outline-variant($color: $primary-color) {
-  background: $light-color;
+@mixin button-outline-variant($color: var(--spectre-primary-color)) {
+  background: var(--spectre-light-color);
   border-color: $color;
   color: $color;
   &:focus {
@@ -35,15 +37,15 @@
   }
   &:focus,
   &:hover {
-    background: lighten($color, 50%);
-    border-color: darken($color, 2%);
+    background: lighten-css($color, 50%);
+    border-color: darken-css($color, 2%);
     color: $color;
   }
   &:active,
   &.active {
     background: $color;
-    border-color: darken($color, 5%);
-    color: $light-color;
+    border-color: darken-css($color, 5%);
+    color: var(--spectre-light-color);
   }
   &.loading {
     &::after {

--- a/src/mixins/_color.scss
+++ b/src/mixins/_color.scss
@@ -1,16 +1,24 @@
+@use "functions/color" as *;
+
 // Background color utility mixin
-@mixin bg-color-variant($name: ".bg-primary", $color: $primary-color) {
+@mixin bg-color-variant($name: ".bg-primary", $color: var(--spectre-primary-color), $light-text: false) {
   #{$name} {
     background: $color !important;
 
-    @if (lightness($color) < 60) {
-      color: $light-color;
+    // TODO: Replace this function with color-contrast when it is supported:
+    // https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast#browser_compatibility
+    @if (type-of($color) == "color") {
+      @if (lightness($color) < 60) {
+        color: var(--spectre-light-color);
+      }
+    } @else if ($light-text) {
+      color: var(--spectre-light-color);
     }
   }
 }
 
 // Text color utility mixin
-@mixin text-color-variant($name: ".text-primary", $color: $primary-color) {
+@mixin text-color-variant($name: ".text-primary", $color: var(--spectre-primary-color)) {
   #{$name} {
     color: $color !important;
   }
@@ -18,10 +26,10 @@
   a#{$name} {
     &:focus,
     &:hover {
-      color: darken($color, 5%);
+      color: darken-css($color, 5%);
     }
     &:visited {
-      color: lighten($color, 5%);
+      color: lighten-css($color, 5%);
     }
   }
 }

--- a/src/mixins/_label.scss
+++ b/src/mixins/_label.scss
@@ -5,7 +5,7 @@
   padding: .1rem .2rem;
 }
 
-@mixin label-variant($color: $light-color, $bg-color: $primary-color) {
+@mixin label-variant($color: var(--spectre-light-color), $bg-color: var(--spectre-primary-color)) {
   background: $bg-color;
   color: $color;
 }

--- a/src/mixins/_shadow.scss
+++ b/src/mixins/_shadow.scss
@@ -1,9 +1,11 @@
+@use "functions/color" as *;
+
 // Component focus shadow
-@mixin control-shadow($color: $primary-color) {
-  box-shadow: 0 0 0 .1rem rgba($color, .2);
+@mixin control-shadow($color: var(--spectre-primary-color)) {
+  box-shadow: 0 0 0 .1rem opacity-css($color, .2);
 }
 
 // Shadow mixin
 @mixin shadow-variant($offset) {
-  box-shadow: 0 $offset ($offset + .05rem) * 2 rgba($dark-color, .3);
+  box-shadow: 0 $offset ($offset + .05rem) * 2 opacity-css(var(--spectre-dark-color), .3);
 }

--- a/src/mixins/_toast.scss
+++ b/src/mixins/_toast.scss
@@ -1,5 +1,7 @@
+@use "functions/color" as *;
+
 // Toast variant mixin
-@mixin toast-variant($color: $dark-color) {
-  background: rgba($color, .95);
+@mixin toast-variant($color: var(--spectre-dark-color)) {
+  background: opacity-css($color, .95);
   border-color: $color;
 }

--- a/src/spectre.scss
+++ b/src/spectre.scss
@@ -3,6 +3,9 @@
 @import "mixins";
 
 /*! Spectre.css v#{$version} | MIT License | github.com/picturepan2/spectre */
+// CSS variables
+@import "variables-css";
+
 // Reset and dependencies
 @import "normalize";
 @import "base";

--- a/src/utilities/_colors.scss
+++ b/src/utilities/_colors.scss
@@ -1,31 +1,31 @@
 // Text colors
-@include text-color-variant(".text-primary", $primary-color);
+@include text-color-variant(".text-primary", var(--spectre-primary-color));
 
-@include text-color-variant(".text-secondary", $secondary-color-dark);
+@include text-color-variant(".text-secondary", var(--spectre-secondary-color-dark));
 
-@include text-color-variant(".text-gray", $gray-color);
+@include text-color-variant(".text-gray", var(--spectre-gray-color));
 
-@include text-color-variant(".text-light", $light-color);
+@include text-color-variant(".text-light", var(--spectre-light-color));
 
-@include text-color-variant(".text-dark", $body-font-color);
+@include text-color-variant(".text-dark", var(--spectre-body-font-color));
 
-@include text-color-variant(".text-success", $success-color);
+@include text-color-variant(".text-success", var(--spectre-success-color));
 
-@include text-color-variant(".text-warning", $warning-color);
+@include text-color-variant(".text-warning", var(--spectre-warning-color));
 
-@include text-color-variant(".text-error", $error-color);
+@include text-color-variant(".text-error", var(--spectre-error-color));
 
 // Background colors
-@include bg-color-variant(".bg-primary", $primary-color);
+@include bg-color-variant(".bg-primary", var(--spectre-primary-color), true);
 
-@include bg-color-variant(".bg-secondary", $secondary-color);
+@include bg-color-variant(".bg-secondary", var(--spectre-secondary-color), false);
 
-@include bg-color-variant(".bg-dark", $dark-color);
+@include bg-color-variant(".bg-dark", var(--spectre-dark-color), true);
 
-@include bg-color-variant(".bg-gray", $bg-color);
+@include bg-color-variant(".bg-gray", var(--spectre-bg-color), false);
 
-@include bg-color-variant(".bg-success", $success-color);
+@include bg-color-variant(".bg-success", var(--spectre-success-color), true);
 
-@include bg-color-variant(".bg-warning", $warning-color);
+@include bg-color-variant(".bg-warning", var(--spectre-warning-color), true);
 
-@include bg-color-variant(".bg-error", $error-color);
+@include bg-color-variant(".bg-error", var(--spectre-error-color), true);

--- a/src/utilities/_divider.scss
+++ b/src/utilities/_divider.scss
@@ -5,8 +5,8 @@
   position: relative;
 
   &[data-content]::after {
-    background: $bg-color-light;
-    color: $gray-color;
+    background: var(--spectre-bg-color-light);
+    color: var(--spectre-gray-color);
     content: attr(data-content);
     display: inline-block;
     font-size: $font-size-sm;
@@ -16,7 +16,7 @@
 }
 
 .divider {
-  border-top: $border-width solid $border-color-light;
+  border-top: $border-width solid var(--spectre-border-color-light);
   height: $border-width;
   margin: $unit-2 0;
 
@@ -30,7 +30,7 @@
   padding: $unit-4;
 
   &::before {
-    border-left: $border-width solid $border-color;
+    border-left: $border-width solid var(--spectre-border-color);
     bottom: $unit-2;
     content: "";
     display: block;

--- a/src/utilities/_loading.scss
+++ b/src/utilities/_loading.scss
@@ -7,7 +7,7 @@
   &::after {
     animation: loading 500ms infinite linear;
     background: transparent;
-    border: $border-width-lg solid $primary-color;
+    border: $border-width-lg solid var(--spectre-primary-color);
     border-radius: 50%;
     border-right-color: transparent;
     border-top-color: transparent;


### PR DESCRIPTION
This is a partial implementation of #19 - I decided to split it into separate PR's for each type of variable, since the changes are so massive, and there are unique challenges for each type of variable.

Ps. this requires that you merge https://github.com/spectre-org/spectre-docs/pull/15 because none of this works in Internet Explorer.

This solution is fully backwards compatible, making sure that everything in sass still works as it did before. The addition is that you can now ignore the sass variables and instead change the variables directly in CSS. The native variables are nearly as powerful as the sass variables, with the single downside being that the color of text in buttons will not change between dark and light depending on how dark the background is. That feature is not yet supported in browsers.

There is one detail to be aware of: now that the colors are transformed with CSS rather than Sass functions, the output colors are a tiny bit different. This is apparently because Sass transforms the colors incorrectly and CSS does it correctly. The difference is very hard to notice and I don't think it will be a major problem. But the change should probably be published as semver-major just to be safe.

