### PR TITLE
Update normalizations

### DIFF
--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -15,6 +15,15 @@ legend {
   margin-bottom: $layout-spacing-lg;
 }
 
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-size: inherit;
+  line-height: inherit;
+}
+
 // Form element: Label
 .form-label {
   display: block;

--- a/src/_normalize.scss
+++ b/src/_normalize.scss
@@ -1,446 +1,236 @@
-/* Manually forked from Normalize.css */
-/* normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
+/** 
+Manually forked from modern-normalize with some removals:
+
+- r1 Box model, already set by spectre.
+- r2 Font family, already set by spectre.
+- r3 Line height, already set by spectre.
+- r4 Monospace font family, already set by spectre.
+- r5 Font size and line height on form elements, already set by spectre.
+
+And some temporary removals:
+- tr1 Tab size, to ensure backwards compatibility with spectre v1. TODO: Add this back when releasing spectre v2.
+- tr2 Table border color, to ensure backwards compatibility with spectre v1. TODO: Add this back when releasing spectre v2.
+
+To make it easier to update this fork with upstream changes, please only remove code, and remove it by commenting it out.
+If you need to change or add something, do it in the upstream repo or do it in a different file.
+*/
+/*! modern-normalize v3.0.0 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
 
 /**
- * 1. Change the default font family in all browsers (opinionated).
- * 2. Correct the line height in all browsers.
- * 3. Prevent adjustments of font size after orientation changes in
- *    IE on Windows Phone and in iOS.
- */
+Use a better box model (opinionated).
+*/
 
-/* Document
-   ========================================================================== */
+/* r1 */
+// *,
+// ::before,
+// ::after {
+// 	box-sizing: border-box;
+// }
 
 html {
-  font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 3 */
-  -webkit-text-size-adjust: 100%; /* 3 */
+	/* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
+	/* r2 */
+	// font-family:
+	//  system-ui,
+	//  'Segoe UI',
+	//  Roboto,
+	//  Helvetica,
+	//  Arial,
+	//  sans-serif,
+	//  'Apple Color Emoji',
+	//  'Segoe UI Emoji';
+	/* r3 */
+	// line-height: 1.15; /* 1. Correct the line height in all browsers. */
+	-webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
+	/* tr1 */
+	// tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
 }
 
-/* Sections
-   ========================================================================== */
-
-/**
- * Remove the margin in all browsers (opinionated).
- */
+/*
+Sections
+========
+*/
 
 body {
-  margin: 0;
+	margin: 0; /* Remove the margin in all browsers. */
 }
 
-/**
- * Add the correct display in IE 9-.
- */
-
-article,
-aside,
-footer,
-header,
-nav,
-section {
-  display: block;
-}
+/*
+Text-level semantics
+====================
+*/
 
 /**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
-}
-
-/* Grouping content
-   ========================================================================== */
-
-/**
- * Add the correct display in IE 9-.
- * 1. Add the correct display in IE.
- */
-
-figcaption,
-figure,
-main { /* 1 */
-  display: block;
-}
-
-/**
- * Add the correct margin in IE 8 (removed).
- */
-
-/**
- * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
- */
-
-hr {
-  box-sizing: content-box; /* 1 */
-  height: 0; /* 1 */
-  overflow: visible; /* 2 */
-}
-
-/**
- * 1. Correct the inheritance and scaling of font size in all browsers. (removed)
- * 2. Correct the odd `em` font sizing in all browsers.
- */
-
-/* Text-level semantics
-   ========================================================================== */
-
-/**
- * 1. Remove the gray background on active links in IE 10.
- * 2. Remove gaps in links underline in iOS 8+ and Safari 8+.
- */
-
-a {
-  background-color: transparent; /* 1 */
-  -webkit-text-decoration-skip: objects; /* 2 */
-}
-
-/**
- * Remove the outline on focused links when they are also active or hovered
- * in all browsers (opinionated).
- */
-
-a:active,
-a:hover {
-  outline-width: 0;
-}
-
-/**
- * Modify default styling of address.
- */
-
-address {
-  font-style: normal;
-}
-
-/**
- * 1. Remove the bottom border in Firefox 39-.
- * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari. (removed)
- */
-
-/**
- * Prevent the duplicate application of `bolder` by the next rule in Safari 6.
- */
+Add the correct font weight in Chrome and Safari.
+*/
 
 b,
 strong {
-  font-weight: inherit;
+	font-weight: bolder;
 }
 
 /**
- * Add the correct font weight in Chrome, Edge, and Safari.
- */
-
-b,
-strong {
-  font-weight: bolder;
-}
-
-/**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
- */
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
 
 code,
 kbd,
-pre,
-samp {
-  font-family: $mono-font-family; /* 1 (changed) */
-  font-size: 1em; /* 2 */
+samp,
+pre {
+	/* r4 */
+	// font-family:
+	// 	ui-monospace,
+	// 	SFMono-Regular,
+	// 	Consolas,
+	// 	'Liberation Mono',
+	// 	Menlo,
+	// 	monospace; /* 1 */
+	font-size: 1em; /* 2 */
 }
 
 /**
- * Add the correct font style in Android 4.3-.
- */
-
-dfn {
-  font-style: italic;
-}
-
-/**
- * Add the correct background and color in IE 9-. (Removed)
- */
-
-/**
- * Add the correct font size in all browsers.
- */
+Add the correct font size in all browsers.
+*/
 
 small {
-  font-size: 80%;
-  font-weight: 400; /* (added) */
+	font-size: 80%;
 }
 
 /**
- * Prevent `sub` and `sup` elements from affecting the line height in
- * all browsers.
- */
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
 
 sub,
 sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline;
+	font-size: 75%;
+	line-height: 0;
+	position: relative;
+	vertical-align: baseline;
 }
 
 sub {
-  bottom: -0.25em;
+	bottom: -0.25em;
 }
 
 sup {
-  top: -.5em;
+	top: -0.5em;
 }
 
-/* Embedded content
-   ========================================================================== */
+/*
+Tabular data
+============
+*/
 
 /**
- * Add the correct display in IE 9-.
- */
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
 
-audio,
-video {
-  display: inline-block;
-}
+/* tr2 */
+// table {
+// 	border-color: currentcolor;
+// }
 
-/**
- * Add the correct display in iOS 4-7.
- */
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
+/*
+Forms
+=====
+*/
 
 /**
- * Remove the border on images inside links in IE 10-.
- */
-
-img {
-  border-style: none;
-}
-
-/**
- * Hide the overflow in IE.
- */
-
-svg:not(:root) {
-  overflow: hidden;
-}
-
-/* Forms
-   ========================================================================== */
-
-/**
- * 1. Change the font styles in all browsers (opinionated).
- * 2. Remove the margin in Firefox and Safari.
- */
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
 
 button,
 input,
 optgroup,
 select,
 textarea {
-  font-family: inherit; /* 1 (changed) */
-  font-size: inherit; /* 1 (changed) */
-  line-height: inherit; /* 1 (changed) */
-  margin: 0; /* 2 */
+	font-family: inherit; /* 1 */
+	/* r5 */
+	// font-size: 100%; /* 1 */
+	// line-height: 1.15; /* 1 */
+	margin: 0; /* 2 */
 }
 
 /**
- * Show the overflow in IE.
- * 1. Show the overflow in Edge.
- */
+Correct the inability to style clickable types in iOS and Safari.
+*/
 
 button,
-input { /* 1 */
-  overflow: visible;
+[type='button'],
+[type='reset'],
+[type='submit'] {
+	-webkit-appearance: button;
 }
 
 /**
- * Remove the inheritance of text transform in Edge, Firefox, and IE.
- * 1. Remove the inheritance of text transform in Firefox.
- */
-
-button,
-select { /* 1 */
-  text-transform: none;
-}
-
-/**
- * 1. Prevent a WebKit bug where (2) destroys native `audio` and `video`
- *    controls in Android 4.
- * 2. Correct the inability to style clickable types in iOS and Safari.
- */
-
-button,
-html [type="button"], /* 1 */
-[type="reset"],
-[type="submit"] {
-  -webkit-appearance: button; /* 2 */
-}
-
-/**
- * Remove the inner border and padding in Firefox.
- */
-
-button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
-  border-style: none;
-  padding: 0;
-}
-
-/**
- * Restore the focus styles unset by the previous rule (removed).
- */
-
-
-/**
- * Change the border, margin, and padding in all browsers (opinionated) (changed).
- */
-
-fieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-/**
- * 1. Correct the text wrapping in Edge and IE.
- * 2. Correct the color inheritance from `fieldset` elements in IE.
- * 3. Remove the padding so developers are not caught out when they zero out
- *    `fieldset` elements in all browsers.
- */
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
 
 legend {
-  box-sizing: border-box; /* 1 */
-  color: inherit; /* 2 */
-  display: table; /* 1 */
-  max-width: 100%; /* 1 */
-  padding: 0; /* 3 */
-  white-space: normal; /* 1 */
+	padding: 0;
 }
 
 /**
- * 1. Add the correct display in IE 9-.
- * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
- */
+Add the correct vertical alignment in Chrome and Firefox.
+*/
 
 progress {
-  display: inline-block; /* 1 */
-  vertical-align: baseline; /* 2 */
+	vertical-align: baseline;
 }
 
 /**
- * Remove the default vertical scrollbar in IE.
- */
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
 
-textarea {
-  overflow: auto;
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+	height: auto;
 }
 
 /**
- * 1. Add the correct box sizing in IE 10-.
- * 2. Remove the padding in IE 10-.
- */
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
 
-[type="checkbox"],
-[type="radio"] {
-  box-sizing: border-box; /* 1 */
-  padding: 0; /* 2 */
+[type='search'] {
+	-webkit-appearance: textfield; /* 1 */
+	outline-offset: -2px; /* 2 */
 }
 
 /**
- * Correct the cursor style of increment and decrement buttons in Chrome.
- */
+Remove the inner padding in Chrome and Safari on macOS.
+*/
 
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
-  height: auto;
+::-webkit-search-decoration {
+	-webkit-appearance: none;
 }
 
 /**
- * 1. Correct the odd appearance in Chrome and Safari.
- * 2. Correct the outline style in Safari.
- */
-
-[type="search"] {
-  -webkit-appearance: textfield; /* 1 */
-  outline-offset: -2px; /* 2 */
-}
-
-/**
- * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
- */
-
-[type="search"]::-webkit-search-cancel-button,
-[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none;
-}
-
-/**
- * 1. Correct the inability to style clickable types in iOS and Safari.
- * 2. Change font properties to `inherit` in Safari.
- */
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
 
 ::-webkit-file-upload-button {
-  -webkit-appearance: button; /* 1 */
-  font: inherit; /* 2 */
-}
-
-/* Interactive
-   ========================================================================== */
-
-/*
- * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
- */
-
-details, /* 1 */
-menu {
-  display: block;
+	-webkit-appearance: button; /* 1 */
+	font: inherit; /* 2 */
 }
 
 /*
- * Add the correct display in all browsers.
- */
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
 
 summary {
-  display: list-item;
-  outline: none;
-}
-
-/* Scripting
-   ========================================================================== */
-
-/**
- * Add the correct display in IE 9-.
- */
-
-canvas {
-  display: inline-block;
-}
-
-/**
- * Add the correct display in IE.
- */
-
-template {
-  display: none;
-}
-
-/* Hidden
-   ========================================================================== */
-
-/**
- * Add the correct display in IE 10-.
- */
-
-[hidden] {
-  display: none;
+	display: list-item;
 }

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -76,6 +76,17 @@ mark {
   padding: $unit-o $unit-h 0;
 }
 
+address {
+  font-style: normal;
+}
+
+code,
+kbd,
+samp,
+pre {
+  font-family: $mono-font-family;
+}
+
 // Blockquote
 blockquote {
   border-left: $border-width-lg solid $border-color;


### PR DESCRIPTION
The original normlization sheet [normalize.css](https://github.com/necolas/normalize.css) has not been updated for many years, and includes fixes for extremely outdated browsers. I found a fork [modern-normalize](https://github.com/sindresorhus/modern-normalize) that I trust, which I think the project should switch to instead. This removes a lot of CSS that is either unnecessary or harmful in modern browsers.

I found a few declarations that were added in this repo, but were never part of `normalize.css`. I have moved those to their respective stylesheets were I think they are more appropriate. There was only one custom change that was an actual normalization, but it is no longer needed in modern browsers, so I just removed it.

This change is theoretically only a `semver-minor` change, so you can add it and publish it immediately. There are some new declarations in `modern-normalize` which I have temporarily removed specifically to make this a `semver-minor` change. Next time you want to do a major change, those declarations should be added back.