### PR TITLE
Update sass/dart build deps and fix broken buildDocs task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,7 @@ import csscomb from 'gulp-csscomb'
 import rename from 'gulp-rename'
 import replace from 'gulp-replace'
 import gulpIf from 'gulp-if'
+import merge from 'merge-stream'
 import autoprefixer from 'gulp-autoprefixer'
 import prefixSelector from 'postcss-prefix-selector'
 import prefixer from 'postcss-prefixer'
@@ -31,7 +32,7 @@ export function build () {
   return gulp
     .src('./src/*.scss')
     .pipe(replace(/%VERSION%/g, `v${version}`))
-    .pipe(sass({ style: 'compact', precision: 10 })
+    .pipe(sass({ style: 'expanded' })
       .on('error', sass.logError)
     )
     .pipe(autoprefixer())
@@ -60,16 +61,20 @@ export function buildDocs () {
   // copy docs stylesheets
   const output = `${DOCS_PATH}/.vitepress/theme/styles/spectre`
   const options = { output, minOnly: true }
-  isolate('namespace', '.vp-doc', options)
+  const streams = [isolate('namespace', '.vp-doc', options)]
 
   // update version string
   const index = `${DOCS_PATH}/index.md`
   if (Fs.existsSync(index)) {
-    gulp
-      .src(index, { base: '.' })
-      .pipe(replace(/tagline: ".+?"/, `tagline: "Latest version: v${version}"`))
-      .pipe(gulp.dest('.'))
+    streams.push(
+      gulp
+        .src(index, { base: '.' })
+        .pipe(replace(/tagline: ".+?"/, `tagline: "Latest version: v${version}"`))
+        .pipe(gulp.dest('.'))
+    )
   }
+
+  return merge(streams)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,17 +38,18 @@
   },
   "devDependencies": {
     "gulp": "^5.0.0",
-    "gulp-autoprefixer": "^9.0.0",
+    "gulp-autoprefixer": "^10.0.0",
     "gulp-clean-css": "^4.3.0",
     "gulp-csscomb": "^3.1.0",
     "gulp-if": "^3.0.0",
     "gulp-postcss": "^10.0.0",
     "gulp-rename": "^2.0.0",
     "gulp-replace": "^1.1.4",
-    "gulp-sass": "^5.1.0",
-    "postcss-prefix-selector": "^1.16.1",
+    "gulp-sass": "^6.0.1",
+    "merge-stream": "^2.0.0",
+    "postcss-prefix-selector": "^2.1.1",
     "postcss-prefixer": "^3.0.0",
-    "sass": "^1.77.8"
+    "sass": "^1.102.0"
   },
   "browserslist": [
     "last 4 Chrome versions",


### PR DESCRIPTION
## Summary
- Bumps `sass`, `gulp-sass`, `gulp-autoprefixer`, and `postcss-prefix-selector` to their latest majors.
- `gulp-sass` 6 dropped the `compact` output style and the `precision` option, so `gulpfile.js` now uses `style: 'expanded'`.
- Fixes `buildDocs` never signaling completion to gulp (it discarded the streams from `isolate()`/`gulp.src()` instead of returning them) — now returns a merged stream via `merge-stream`.

Note: this does **not** address the Dart Sass `@import`/legacy color-function deprecation warnings coming from the `src/*.scss` source itself (tracked in #54) — that's a larger migration to `@use`/`@forward` and `color.adjust()`/`color.scale()`, planned as a separate PR.

## Test plan
- [x] `npm run build` completes cleanly, produces all 6 expected dist files at expected sizes
- [x] `npm run docs:build` completes cleanly against a cloned `spectre-docs` sibling repo, writes the 3 expected namespaced/minified stylesheets, no more "did you forget to signal async completion" warning