### PR TITLE
Fix visited buttons, loading spinner, select colour and details marker

### DIFF
--- a/src/_accordions.scss
+++ b/src/_accordions.scss
@@ -30,8 +30,12 @@
   }
 }
 
-// Remove default details marker in Webkit
+// Remove the default details marker
+// `list-style` covers modern browsers, the Webkit pseudo-element covers older Safari.
+// Note that `::marker` cannot be used here, as it does not accept the `display` property.
 summary.accordion-header {
+  list-style: none;
+
   &::-webkit-details-marker {
     display: none;
   }

--- a/src/_buttons.scss
+++ b/src/_buttons.scss
@@ -18,6 +18,10 @@
   user-select: none;
   vertical-align: middle;
   white-space: nowrap;
+  // Anchors styled as buttons would otherwise pick up the browser's visited colour
+  &:visited {
+    color: $primary-color;
+  }
   &:focus {
     @include control-shadow();
   }
@@ -53,6 +57,9 @@
     background: $primary-color;
     border-color: $primary-color-dark;
     color: $light-color;
+    &:visited {
+      color: $light-color;
+    }
     &:focus,
     &:hover {
       background: darken($primary-color-dark, 2%);
@@ -87,6 +94,9 @@
     background: transparent;
     border-color: transparent;
     color: $link-color;
+    &:visited {
+      color: $link-color;
+    }
     &:focus,
     &:hover,
     &:active,

--- a/src/_forms.scss
+++ b/src/_forms.scss
@@ -123,7 +123,7 @@ textarea.form-input {
   appearance: none;
   border: $border-width solid $border-color-dark;
   border-radius: $border-radius;
-  color: inherit;
+  color: $body-font-color;
   font-size: $font-size;
   height: $control-size;
   line-height: $line-height;

--- a/src/mixins/_button.scss
+++ b/src/mixins/_button.scss
@@ -3,6 +3,9 @@
   background: $color;
   border-color: darken($color, 3%);
   color: $light-color;
+  &:visited {
+    color: $light-color;
+  }
   &:focus {
     @include control-shadow($color);
   }

--- a/src/utilities/_loading.scss
+++ b/src/utilities/_loading.scss
@@ -1,6 +1,11 @@
 // Loading
 .loading {
-  color: transparent !important;
+  // Hide child text as well as direct text, so nested content does not show through the spinner
+  &,
+  * {
+    color: transparent !important;
+  }
+
   min-height: $unit-4;
   pointer-events: none;
   position: relative;
@@ -14,13 +19,14 @@
     content: "";
     display: block;
     height: $unit-4;
-    left: 50%;
+    // `!important` keeps the spinner centred when the host element sets its own offsets
+    left: 50% !important;
     margin-left: -$unit-2;
     margin-top: -$unit-2;
     opacity: 1;
     padding: 0;
     position: absolute;
-    top: 50%;
+    top: 50% !important;
     width: $unit-4;
     z-index: $zindex-0;
   }


### PR DESCRIPTION
Part of the v1.2.1 housekeeping release described in #56. Five bug fixes surfaced by the #5 / #14 backlog triage, each verified against current source as still unfixed.

| Fix | Source |
| --- | --- |
| `form-select` used `color: inherit`, picking up whatever colour its container set rather than the body font colour | upstream [#660](https://github.com/picturepan2/spectre/pull/660) |
| `.loading` only hid its own text, so nested content showed through the spinner | upstream [#400](https://github.com/picturepan2/spectre/pull/400) |
| The `.loading` spinner lost its centring when the host element set its own offsets | upstream [#650](https://github.com/picturepan2/spectre/pull/650) |
| Anchors styled as buttons picked up the browser's visited colour | upstream `0.5.10` |
| Deprecated `::-webkit-details-marker` on accordion headers | upstream [#674](https://github.com/picturepan2/spectre/pull/674) |

## Two deliberate departures from upstream

**The details marker fix.** Upstream #674 swaps the Webkit pseudo-element for `::marker { display: none }`. That does not work — `::marker` only accepts a restricted set of properties, and `display` is not among them, so the rule is dropped and the triangle stays. This uses `list-style: none` for modern browsers instead, keeping `::-webkit-details-marker` for older Safari.

**Visited button colours.** `0.5.10` sets visited `.btn` to `$primary-color-dark`, which makes visited buttons visibly darker than unvisited ones. Since the bug being fixed is "visited buttons render purple", each variant is set to its own default colour instead — so the fix removes the browser default without introducing a new visual distinction. Worth a second opinion if the darker shade was intended as a feature.

## Verification

`npm run build` succeeds, and the compiled `dist/spectre.css` diff against `main` contains exactly these changes and nothing else:

- `.btn:visited`, `.btn.btn-primary:visited`, `.btn.btn-success:visited`, `.btn.btn-error:visited`, `.btn.btn-link:visited` — colour only
- `summary.accordion-header { list-style: none }`
- `.form-select` — `color: inherit` to body font colour
- `.loading` — now also matches `.loading *`
- `.loading::after` — `left` / `top` `50%` to `50% !important`

One cosmetic note, pre-existing and not addressed here: `$body-font-color` compiles to `rgb(23.03%, 26.39%, 31.67%)` rather than a hex value, as it already does in 16 other places in the stylesheet. That is a Dart Sass output artefact worth fixing separately.

Not included in this PR, both needing verification I could not do unattended: #42 (Meter) needs visual confirmation in a browser, and #52 (`dist/` in releases) needs a release workflow that cannot be tested without pushing a tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
